### PR TITLE
Pb 101521

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation for the SDK can be accessed [here](http://bit.ly/2uN6Rlz).
 For help, use OneSpan's [Developer Community](http://bit.ly/2uJz52e).
 
 ## Installation and Configuration
-The SDK can be installed using the <a href="https://githubsfdeploy.herokuapp.com?owner=KadenceCollective&repo=esignlive-apex-sdk">
+The SDK can be installed using the <a href="https://githubsfdeploy.herokuapp.com?owner=KadenceCollective&repo=onespan-sign-apex-sdk">
   <img alt="Deploy to Salesforce"
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png">
 </a> button.

--- a/src/classes/OneSpanRESTAPIHelper.cls
+++ b/src/classes/OneSpanRESTAPIHelper.cls
@@ -144,7 +144,7 @@ public with sharing class OneSpanRESTAPIHelper
     {
         // Send Request
         String resourceUrl = '/packages/' + packageId + '/roles/' + signerId + '/signingUrl';
-        HttpResponse response = doGet(resourceUrl);
+        HttpResponse response = doGetWithoutPrepareInboundJSON(resourceUrl);
 
         // Check response
         OneSpanAPIObjects.SigningUrl signingUrl;
@@ -902,6 +902,30 @@ public with sharing class OneSpanRESTAPIHelper
 
         return response;
     }
+
+    /**
+     * Utility method to handle GET callouts without Prepare Inbound JSON
+     */
+    private HttpResponse doGetWithoutPrepareInboundJSON(String resourceUrl)
+    {
+        // Build Request
+        HttpRequest request = new HttpRequest();
+        request.setEndpoint(connectionSettings.Endpoint__c + resourceUrl);
+        request.setMethod('GET');
+        request.setHeader('Authorization', 'Basic ' + connectionSettings.API_Key__c);
+        request.setHeader('Content-type', 'application/json');
+
+        // Send Request
+        HttpResponse response = (new Http()).send(request);
+
+        if(response != null && (response.getHeader('Content-Type')).contains('json'))
+        {
+            response.setBody(response.getBody());
+        }
+
+        return response;
+    }
+
 
     /**
      * Utility method to handle DELETE callouts

--- a/src/classes/OneSpanRESTAPIHelperTest.cls
+++ b/src/classes/OneSpanRESTAPIHelperTest.cls
@@ -91,7 +91,7 @@ public class OneSpanRESTAPIHelperTest
             String packageId = 'a3b023bf-db56-4c53-b36e-bd9acd0579f4';
             String signerId = '654321';
             String roleId = '2jsTTXD2dZMZ';
-            String url =  'https://sandbox.e-signlive.com/auth?target=https%3A%2F%2Fsandbox.e-signlive.com%2Fpackages%2Fa3b023bf-db56-4c53-b36e-bd9acd0579f4%2Fsign&loginToken=Mi4xMDAwGpGY3JJPS55ZnNSeHBmekNxc1RzdnNJRVlBSDkZBR1RhcmxKS09aZ3M4aFZXVlpvdExrdz09';
+            String url =  'https://sandbox.e-signlive.com/auth?target=https%3A%2F%2Fsandbox.e-signlive.com%2Fpackages%2Fa3b023bf-db56-4c53-b36e-bd9acd0579f4%2Fsign&loginToken=NEWenumfromgroupPACKAGEPACKAGE_X_XMi4xMDAwGpGY3JJPS55ZnNSeHBmekNxc1RzdnNJRVlBSDkZBR1RhcmxKS09aZ3M4aFZXVlpvdExrdz09';
             OneSpanAPIObjects.SigningUrl su = new OneSpanAPIObjects.SigningUrl(roleId, url, packageId);
             
             // Set response object
@@ -111,7 +111,7 @@ public class OneSpanRESTAPIHelperTest
         
         // Verify response received contains fake values
         System.assertEquals('2jsTTXD2dZMZ', response.roleId);
-        System.assertEquals('https://sandbox.e-signlive.com/auth?target=https%3A%2F%2Fsandbox.e-signlive.com%2Fpackages%2Fa3b023bf-db56-4c53-b36e-bd9acd0579f4%2Fsign&loginToken=Mi4xMDAwGpGY3JJPS55ZnNSeHBmekNxc1RzdnNJRVlBSDkZBR1RhcmxKS09aZ3M4aFZXVlpvdExrdz09', response.url);
+        System.assertEquals('https://sandbox.e-signlive.com/auth?target=https%3A%2F%2Fsandbox.e-signlive.com%2Fpackages%2Fa3b023bf-db56-4c53-b36e-bd9acd0579f4%2Fsign&loginToken=NEWenumfromgroupPACKAGEPACKAGE_X_XMi4xMDAwGpGY3JJPS55ZnNSeHBmekNxc1RzdnNJRVlBSDkZBR1RhcmxKS09aZ3M4aFZXVlpvdExrdz09', response.url);
         System.assertEquals('a3b023bf-db56-4c53-b36e-bd9acd0579f4', response.packageId);
     }
 


### PR DESCRIPTION
Hi Kadence team,

I am Duo Liang, work in OneSpan Sign. As per the ticket PB-101521, we pinpointed an issue when the signing URL contains reserved words like "NEW", "enum" which will be mistakenly replaced by "NEW_X", "enum_x" and will invadate the signing URL. This purposed code fix is to receive the inbound JSON without replacing the reserved words.

Best Regards,
Duo Liang
duo.liang@onespan.com